### PR TITLE
Add ability to pass an array for either `UserAgent` or `Disallow`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -10,21 +10,63 @@ app.use(robots(__dirname + '/robots.txt'));
 
 ## Using an object
 
+### Basic object
+
 ```javascript
 app.use(robots({UserAgent: '*', Disallow: '/'}))
 ```
 
-Or
+#### Will produce:
+```
+UserAgent: *
+Disallow: /
+```
+
+### Or an array of objects
 
 ```javascript
 app.use(robots([
   {
     UserAgent: 'Googlebot',
-    Disallow: '/nogoogle'
+    Disallow: '/no-google'
   },
   {
     UserAgent: 'Bingbot',
-    Disallow: '/nobing'
+    Disallow: '/no-bing'
   }
 ]));
+```
+
+#### Will produce:
+```
+UserAgent: Googlebot
+Disallow: /no-google
+UserAgent: Bingbot
+Disallow: /no-bing
+```
+
+### Or either property (UserAgent | Disallow) as an array
+
+```javascript
+app.use(robots([
+  {
+    UserAgent: [ 'Googlebot', 'Slurp' ],
+    Disallow: [ '/no-google', '/no-yahoo' ]
+  },
+  {
+    UserAgent: '*',
+    Disallow: [ '/no-bots', '/still-no-bots' ]
+  }
+]));
+```
+
+#### Will produce:
+```
+UserAgent: Googlebot
+UserAgent: Slurp
+Disallow: /no-google
+Disallow: /no-yahoo
+UserAgent: *
+Disallow: /no-bots
+Disallow: /still-no-bots
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 var fs = require('fs');
 var asArray = require('as-array');
 
+if (!Array.isArray) {
+  Array.isArray = function(arg) {
+    return Object.prototype.toString.call(arg) === '[object Array]';
+  };
+}
+
 module.exports = function(robots) {
   var app = require('express')();
 
@@ -21,7 +27,20 @@ module.exports = function(robots) {
 
 function render(robots) {
   return asArray(robots).map(function(robot) {
-    return ['User-agent: ' + robot.UserAgent].concat(asArray(robot.Disallow).map(function(disallow) {
+    var userAgentArray = [];
+    if (Array.isArray(robot.UserAgent)) {
+      userAgentArray = robot.UserAgent.map(function(userAgent) {
+        return 'User-agent: ' + userAgent
+      });
+    } else {
+      userAgentArray.push('User-agent: ' + robot.UserAgent);
+    }
+    return userAgentArray.concat(asArray(robot.Disallow).map(function(disallow) {
+      if (Array.isArray(disallow)) {
+        return disallow.map(function(line) {
+          return 'Disallow: ' + line;
+        }).join('\n');
+      }
       return 'Disallow: ' + disallow;
     })).join('\n');
   }).join('\n');


### PR DESCRIPTION
First, thanks for this great module. Saved my bacon. :)

I've updated the README with examples and their outputs.

This helps to produce an output like:

```
User-agent: *
Disallow: /api
Disallow: /build
Disallow: /images
```

instead of

```
User-agent: *
Disallow: /api
User-agent: *
Disallow: /build
User-agent: *
Disallow: /images
```

I haven't tried updating the version, so I'll leave that to you if you're happy with this PR.
