### PR TITLE
Depend on as-array via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/weo-edu/express-robots",
   "dependencies": {
-    "as-array": "git://github.com/weo-edu/as-array"
+    "as-array": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^2.1.0",


### PR DESCRIPTION
This PR updates package.json to use as-array version 2 instead of pointing to the as-array GitHub repository.

This broke our deploys this week. I think it makes sense to use the published as-array from npm.